### PR TITLE
Add vector tiles example

### DIFF
--- a/vectorforge/static/examples/geojsonpoints/index.html
+++ b/vectorforge/static/examples/geojsonpoints/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+  <head>
+    <!--[if !HTML5]>
+    <meta http-equiv="X-UA-Compatible" content="IE=9,IE=10,IE=edge,chrome=1"/>
+    <![endif]-->    
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="/static/css/ol.css">
+    <title>Geojson tiled points</title>
+    <style>
+        #map {
+          width: 100%;
+          height: 450px;
+        }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <a href="index.js">See the code</a><br>
+    <script src="/static/js/jquery-2.0.3.js"></script>
+    <script src="/static/js/proj4js-compressed.js"></script>
+    <script src="/static/js/EPSG21781.js"></script>
+    <script src="/static/js/ol-debug.js"></script>
+    <script src="index.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/vectorforge/static/examples/geojsonpoints/index.js
+++ b/vectorforge/static/examples/geojsonpoints/index.js
@@ -1,0 +1,181 @@
+$(document).ready(function() {
+  var origin = [420000, 350000];
+  var extent = [420000, 30000, 900000, 350000];
+  var defaultResolutions = [4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250,
+      2000, 1750, 1500, 1250, 1000, 750, 650, 500, 250, 100, 50, 20, 10, 5,
+      2.5, 2, 1.5, 1, 0.5];
+
+  var wmtsGetTileUrlTemplate =
+      'http://wmts{5-9}.geo.admin.ch/1.0.0/{Layer}/default/' +
+      '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
+  // TODO add layer reference
+  var vectorGetTileUrlTemplate =
+      '../../../ogcproxy?url=http://wroathiesiuxiefriepl-vectortiles.s3-website-eu-west-1.amazonaws.com/' +
+      '{TileMatrix}/{TileCol}/{TileRow}.{Format}';
+  
+  var getWmtsGetTileUrl = function(layer, format) {
+    return wmtsGetTileUrlTemplate
+        .replace('{Layer}', layer)
+        .replace('{Format}', format);
+  };
+  var getVectorGetTileUrl = function(format) {
+    return vectorGetTileUrlTemplate
+        .replace('{Format}', format);
+  };
+
+  // WMTS layer
+  var tileGridWMTS = new ol.tilegrid.WMTS({
+    matrixIds: $.map(defaultResolutions, function(r, i) { return i + ''; }),
+    origin: origin,
+    resolutions: defaultResolutions
+  });
+  var olSourceWMTS = new ol.source.WMTS({
+    dimensions: {
+      'Time': '20151231'
+    },
+    projection: 'EPSG:21781',
+    requestEncoding: 'REST',
+    tileGrid: tileGridWMTS,
+    url: getWmtsGetTileUrl('ch.swisstopo.pixelkarte-farbe', 'jpeg'),
+    crossOrigin: 'anonymous'
+  });
+  olSourceWMTS.getProjection().setExtent(extent);
+  var olWMTSLayer = new ol.layer.Tile({
+    source: olSourceWMTS,
+    extent: olSourceWMTS.getProjection().getExtent()
+  });
+
+  // VECTOR layer
+  var tileGrid = new ol.tilegrid.WMTS({
+    matrixIds: $.map(defaultResolutions, function(r, i) { return i + ''; }),
+    origin: origin,
+    resolutions: defaultResolutions
+  });
+
+  // https://github.com/openlayers/ol3/blob/master/src/ol/source/wmtssource.js
+  var createFromWMTSTemplate = function(template) {
+
+    // TODO: we may want to create our own appendParams function so that params
+    // order conforms to wmts spec guidance, and so that we can avoid to escape
+    // special template params
+
+    // LG: No context for now
+    var context = {};
+    var dimensions = {};
+    var requestEncoding = 'REST';
+
+    template = (requestEncoding == ol.source.WMTSRequestEncoding.KVP) ?
+        goog.uri.utils.appendParamsFromMap(template, context) :
+        template.replace(/\{(\w+?)\}/g, function(m, p) {
+          return (p.toLowerCase() in context) ? context[p.toLowerCase()] : m;
+        });
+
+    return (
+        /**
+         * @param {ol.TileCoord} tileCoord Tile coordinate.
+         * @param {number} pixelRatio Pixel ratio.
+         * @param {ol.proj.Projection} projection Projection.
+         * @return {string|undefined} Tile URL.
+         */
+        function(tileCoord, pixelRatio, projection) {
+          if (goog.isNull(tileCoord)) {
+            return undefined;
+          } else {
+            var localContext = {
+              'TileMatrix': tileGrid.getMatrixId(tileCoord[0]),
+              'TileCol': tileCoord[1],
+              'TileRow': tileCoord[2]
+            };
+            goog.object.extend(localContext, dimensions);
+            var url = template;
+            if (requestEncoding == ol.source.WMTSRequestEncoding.KVP) {
+              url = goog.uri.utils.appendParamsFromMap(url, localContext);
+            } else {
+              url = url.replace(/\{(\w+?)\}/g, function(m, p) {
+                return localContext[p];
+              });
+            }
+            return url;
+          }
+        });
+  };
+
+  var createTileUrlFunction = function() {
+    var tileUrlFunction = ol.TileUrlFunction.nullTileUrlFunction;
+    urls = ol.TileUrlFunction.expandUrl(getVectorGetTileUrl('geojson'));
+    tileUrlFunction = ol.TileUrlFunction.createFromTileUrlFunctions(
+        goog.array.map(urls, createFromWMTSTemplate));
+    var tmpExtent = ol.extent.createEmpty();
+
+    return ol.TileUrlFunction.withTileCoordTransform(
+        function(tileCoord, projection, opt_tileCoord) {
+          goog.asserts.assert(!goog.isNull(tileGrid),
+            'tileGrid must not be null');
+          if (tileGrid.getResolutions().length <= tileCoord[0]) {
+            return null;
+          }
+          var x = tileCoord[1];
+          var y = -tileCoord[2] - 1;
+          var tileExtent = tileGrid.getTileCoordExtent(tileCoord, tmpExtent);
+          if (!ol.extent.intersects(tileExtent, extent) ||
+              ol.extent.touches(tileExtent, extent)) {
+            return null;
+          }
+          return ol.tilecoord.createOrUpdate(tileCoord[0], x, y, opt_tileCoord);
+      }, tileUrlFunction);
+  };
+
+  var olSourceVector = new ol.source.TileVector({
+    format: new ol.format.GeoJSON({
+      defaultDataProjection: 'EPSG:21781'
+    }),
+    projection: 'EPSG:21781',
+    requestEncoding: 'REST',
+    tileGrid: tileGrid,
+    tileUrlFunction: createTileUrlFunction(),
+    crossOrigin: 'anonymous',
+    extent: extent,
+    origin: origin
+  });
+  olSourceVector.getProjection().setExtent(extent);
+
+  var fill = new ol.style.Fill({
+    color: [250, 106, 106, 0.75]
+  });
+  var stroke =  new ol.style.Stroke({
+    color: [255, 255, 255, 1],
+    width: 2
+  });
+  var olVectorLayer = new ol.layer.Vector({
+    source: olSourceVector,
+    extent: extent,
+    style: [new ol.style.Style({
+      fill: fill,
+      stroke: stroke,
+      image: new ol.style.Circle({
+        radius: 6,
+        fill: fill,
+        stroke: stroke
+      }) 
+    })]
+  });
+
+  var olMap = new ol.Map({
+    logo: false,
+    controls: ol.control.defaults({
+      attributionOptions: {
+        collapsible: false
+      }
+    }),
+    layers: [
+      olWMTSLayer, olVectorLayer
+    ],
+    target: 'map',
+    view: new ol.View({
+      center: [600000, 200000],
+      resolution: 250,
+      extent: extent,
+      projection: 'EPSG:21781'
+    })
+  });
+});

--- a/vectorforge/static/examples/geojsonpoints/index.js
+++ b/vectorforge/static/examples/geojsonpoints/index.js
@@ -172,7 +172,7 @@ $(document).ready(function() {
     ],
     target: 'map',
     view: new ol.View({
-      center: [600000, 200000],
+      center: [650000, 200000],
       resolution: 250,
       extent: extent,
       projection: 'EPSG:21781'

--- a/vectorforge/templates/index.mako
+++ b/vectorforge/templates/index.mako
@@ -12,5 +12,7 @@
     <h2>Demo page for vector tiles</h2>
     <h3>WMTS demo</h3>
     <a href="../../static/examples/basicmap">Pure Ol3 WMTS example</a>
+    <h3>Vector tiles demo</h3>
+    <a href="../../static/examples/geojsonpoints">Pre-generated regular tiles with geojson points</a>
   </body>
 </html>


### PR DESCRIPTION
This PR adds a demo using geojson Tiles. (19'086 points)

The grid one uses is exactly the same we use for our WMTS.

The demo is currently only available in debug mode since I need to export a few things and make our own ol3 build. This will come in a separate PR.

Further work on geojson tiles:

* create custom ol3 build using makefile
* compare performance/resolution if we decide to use ol.source.ImageVector
* add the properties to the points -> performance for dynamic symbology
* points generlalization
* tiles sizes (per zoom level)
* tiles format (topojson etc...)
* webGL