### PR TITLE
Topjson tiled layer demo for ch.swisstopo.vec25-strassennetz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ development.ini
 production.ini
 vector_forge.egg-info
 venv
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ production.ini
 vector_forge.egg-info
 venv
 node_modules
+temp.json
+out.json

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ all: install template lint
 install:
 	virtualenv $(VENV) --distribute
 	$(PYTHON_CMD) setup.py develop
+	npm install
 
 .PHONY: template	
 template:
@@ -51,3 +52,4 @@ clean:
 	rm -rf venv
 	rm -rf vector_forge.egg-info
 	rm -f *.ini
+	rm -rf node_modules

--- a/output.json
+++ b/output.json
@@ -1,0 +1,1 @@
+{"type":"Topology","objects":{"temp":{"crs":{"type":"EPSG","properties":{"code":"21781"}},"type":null}},"arcs":[],"transform":{"scale":[1,1],"translate":[0,0]}}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "topojson": "1.6.19"
+  }
+}

--- a/vectorforge/lib/boto_s3.py
+++ b/vectorforge/lib/boto_s3.py
@@ -29,4 +29,8 @@ def preparePath(layerId, zoomLevel, tileCol, tileRow, tileFormat='geojson'):
 def setFileContent(b, path, featureCollection, contentType='application/json'):
     k = Key(b)
     k.key = path
-    return k.set_contents_from_string(geojson.dumps(featureCollection), headers={'Content-Type': contentType})
+    if isinstance(featureCollection, dict):
+        featureCollection = geojson.dumps(featureCollection)
+    elif isinstance(featureCollection, file):
+        featureCollection = featureCollection.read()
+    return k.set_contents_from_string(featureCollection, headers={'Content-Type': contentType})

--- a/vectorforge/models/__init__.py
+++ b/vectorforge/models/__init__.py
@@ -131,4 +131,6 @@ def formatPropertyValue(prop):
         return prop.__float__()
     elif isinstance(prop, datetime.datetime):
         return prop.strftime("%d.%m.%Y")
+    elif isinstance(prop, str) or isinstance(prop, unicode):
+        return prop.rstrip()
     return prop

--- a/vectorforge/scripts/example_simple_lines.py
+++ b/vectorforge/scripts/example_simple_lines.py
@@ -3,23 +3,75 @@
 import time
 import datetime
 import geojson
-import itertools
+import subprocess
+from sqlalchemy import or_
 from sqlalchemy.orm import scoped_session, sessionmaker
 from geoalchemy2.shape import to_shape
 from geoalchemy2.elements import WKBElement
 from vectorforge.lib.boto_s3 import s3Connect, getBucket, setFileContent, preparePath
 from vectorforge.lib.grid import Grid, RESOLUTIONS
 from vectorforge.models.stopo import Vec25Strassennetz
-from vectorforge.lib.visvaligam import VisvalingamSimplificationFix
 
 
 """
 This script is simplifying lines on the fly using the Visvalingam’s algorithm
-which is not currently available in postgis. Additionnaly, segments smaller than
-the resolution are dropped (brute force approach for testing sake).
+which is not currently available in postgis.
 Explanations can be found at http://bost.ocks.org/mike/simplify/
+We also use quantization and thematic filtering according to the zoom level.
 """
 
+def writeGeojsonFile(data):
+    with open('temp.json', 'w') as outfile:
+        outfile.write(geojson.dumps(data))
+
+def toTopojson(threshold, quantization, prop):
+    """ Try quantization """
+    fileName = 'output.json'
+    subprocess.call([
+        'node_modules/.bin/topojson', '-o', fileName,
+        '--cartesian', '-s', str(threshold), '-q', str(quantization), '-p', prop, 'temp.json'
+    ])
+    return fileName
+
+def clean():
+    subprocess.call(['rm', '-f', 'temp.json'])
+    subprocess.call(['rm', '-f', 'output.json'])
+
+def applyFilters(query, propertyColumn, propertyValues):
+    clauses = []
+    if len(propertyValues) == 1 and propertyValues[0] == '*':
+        return query
+    for prop in propertyValues:
+        clauses.append(propertyColumn == prop)
+    return query.filter(or_(*clauses))
+
+
+zoomFilters = {
+  '0': ['Autobahn'],
+  '1': ['Autobahn'],
+  '2': ['Autobahn'],
+  '3': ['Autobahn'],
+  '4': ['Autobahn'],
+  '5': ['Autobahn'],
+  '6': ['Autobahn'],
+  '7': ['Autobahn'],
+  '8': ['Autobahn'],
+  '9': ['Autobahn'],
+  '10': ['Autobahn', 'Ein_Ausf'],
+  '11': ['Autobahn', 'Ein_Ausf'],
+  '12': ['Autobahn', 'Ein_Ausf'],
+  '13': ['Autobahn', 'Ein_Ausf'],
+  '14': ['Autobahn', 'Ein_Ausf'],
+  '15': ['Autobahn', 'Ein_Ausf'],
+  '16': ['Autobahn', 'Ein_Ausf', '1_Klass'],
+  '17': ['Autobahn', 'Ein_Ausf', '1_Klass', '2_Klass'],
+  '18': ['Autobahn', 'Ein_Ausf', '1_Klass', '2_Klass', '3_Klass'],
+  '19': ['Autobahn', 'Ein_Ausf', '1_Klass', '2_Klass', '3_Klass', '4_Klass'],
+  '20': ['Autobahn', 'Ein_Ausf', '1_Klass', '2_Klass', '3_Klass', '4_Klass', '5_Klass'],
+  '21': ['Autobahn', 'Ein_Ausf', '1_Klass', '2_Klass', '3_Klass', '4_Klass', '5_Klass', '6_Klass'],
+  '22': ['Autobahn', 'Ein_Ausf', '1_Klass', '2_Klass', '3_Klass', '4_Klass', '5_Klass', '6_Klass', 'Q_Klass'],
+  '23': ['*']
+}
 
 t0 = time.time()
 
@@ -27,6 +79,7 @@ conn = s3Connect()
 b = getBucket(conn)
 model = Vec25Strassennetz
 layerId = model.__bodId__
+propertyColumn = model.objectval
 DBSession = scoped_session(sessionmaker())
 
 try:
@@ -39,6 +92,7 @@ try:
         tileCol = 0
         tileRow = 0
         resolution = RESOLUTIONS[zoomLevel]
+        propertyValues = zoomFilters[str(zoomLevel)]
 
         while grid.maxX >= maxX:
             while grid.minY <= minY:
@@ -48,8 +102,7 @@ try:
                 lineMerged = model.lineMerge()
                 query = DBSession.query(model, lineMerged)
                 query = query.filter(model.bboxIntersects(bbox))
-                # Brute force, drop all segments smaller than the resolution
-                query = query.filter(model.length >= float(resolution))
+                query = applyFilters(query, propertyColumn, propertyValues)
 
                 features = []
                 for res in query:
@@ -57,17 +110,15 @@ try:
                     properties = res[0].getProperties()
                     shapelyGeometry = to_shape(WKBElement(buffer(res[1]), 21781))
                     geoJSONFeature = geojson.Feature(ID, geometry=shapelyGeometry, properties=properties)
-                    # Convert tuples to list
-                    coordinates = map(list, geoJSONFeature['geometry']['coordinates'])
-                    simplify = VisvalingamSimplificationFix(coordinates)
-                    coordinates = simplify.simplifyLineString(float(resolution))
-                    # Convert back to tuples
-                    geoJSONFeature['geometry']['coordinates'] = tuple(itertools.imap(tuple, coordinates))
                     features.append(geoJSONFeature) 
                 featureCollection = geojson.FeatureCollection(features, crs={'type': 'EPSG', 'properties': {'code': '21781'}})
+                writeGeojsonFile(featureCollection)
+                fileName = toTopojson(resolution*2, grid.tileSizeInPixel*grid.tileSizeInPixel, 'objectval')
 
-                path = preparePath(layerId, zoomLevel, tileCol, tileRow)
-                setFileContent(b, path, featureCollection)
+                path = preparePath(layerId, zoomLevel, tileCol, tileRow, 'topojson')
+                with open(fileName) as topjsonArcs:
+                    setFileContent(b, path, topjsonArcs)
+                clean()
                 tileRow += 1
             minY = grid.minY
             tileCol += 1
@@ -79,6 +130,10 @@ try:
 except Exception as e:
     print e
 finally:
+    try:
+        clean()
+    except:
+        pass
     DBSession.close()
     t3 = time.time()
     tf = t3 - t0

--- a/vectorforge/static/examples/topojsonlines/fix.js
+++ b/vectorforge/static/examples/topojsonlines/fix.js
@@ -1,0 +1,43 @@
+ol.format.TopoJSON.prototype.readFeaturesFromObject = function(
+    object, opt_options) {
+  // Quick fix
+  if (object.arcs.length == 0) {
+    return [];
+  }
+  if (object.type == 'Topology') {
+    var topoJSONTopology = /** @type {TopoJSONTopology} */ (object);
+    var transform, scale = null, translate = null;
+    if (goog.isDef(topoJSONTopology.transform)) {
+      transform = /** @type {TopoJSONTransform} */
+          (topoJSONTopology.transform);
+      scale = transform.scale;
+      translate = transform.translate;
+    }
+    var arcs = topoJSONTopology.arcs;
+    if (goog.isDef(transform)) {
+      ol.format.TopoJSON.transformArcs_(arcs, scale, translate);
+    }
+    /** @type {Array.<ol.Feature>} */
+    var features = [];
+    var topoJSONFeatures = goog.object.getValues(topoJSONTopology.objects);
+    var i, ii;
+    var feature;
+    for (i = 0, ii = topoJSONFeatures.length; i < ii; ++i) {
+      if (topoJSONFeatures[i].type === 'GeometryCollection') {
+        feature = /** @type {TopoJSONGeometryCollection} */
+            (topoJSONFeatures[i]);
+        features.push.apply(features,
+            ol.format.TopoJSON.readFeaturesFromGeometryCollection_(
+                feature, arcs, scale, translate, opt_options));
+      } else {
+        feature = /** @type {TopoJSONGeometry} */
+            (topoJSONFeatures[i]);
+        features.push(ol.format.TopoJSON.readFeatureFromGeometry_(
+            feature, arcs, scale, translate, opt_options));
+      }
+    }
+    return features;
+  } else {
+    return [];
+  }
+};

--- a/vectorforge/static/examples/topojsonlines/index.html
+++ b/vectorforge/static/examples/topojsonlines/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+  <head>
+    <!--[if !HTML5]>
+    <meta http-equiv="X-UA-Compatible" content="IE=9,IE=10,IE=edge,chrome=1"/>
+    <![endif]-->    
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="/static/css/ol.css">
+    <title>Toposon simplified and quantized lines with thematic filtering</title>
+    <style>
+        #map-toposon {
+          border-bottom-width: 0px !important;
+        }
+        #map-toposon,
+        #map-wmts {
+          width: 100%;
+          height: 300px;
+          border: 1px solid black;
+        }
+    </style>
+  </head>
+  <body>
+    <div id="map-toposon"></div>
+    <div id="map-wmts"></div>
+    <a href="index.js">See the code</a><br>
+    <script src="/static/js/jquery-2.0.3.js"></script>
+    <script src="/static/js/proj4js-compressed.js"></script>
+    <script src="/static/js/EPSG21781.js"></script>
+    <script src="/static/js/ol-debug.js"></script>
+    <script src="fix.js"></script>
+    <script src="index.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/vectorforge/static/examples/topojsonlines/index.js
+++ b/vectorforge/static/examples/topojsonlines/index.js
@@ -1,0 +1,209 @@
+$(document).ready(function() {
+  var origin = [420000, 350000];
+  var extent = [420000, 30000, 900000, 350000];
+  var defaultResolutions = [4000, 3750, 3500, 3250, 3000, 2750, 2500, 2250,
+      2000, 1750, 1500, 1250, 1000, 750, 650, 500, 250, 100, 50, 20, 10, 5,
+      2.5, 2];
+
+  var wmtsGetTileUrlTemplate =
+      'http://wmts{5-9}.geo.admin.ch/1.0.0/{Layer}/default/' +
+      '{Time}/21781/{TileMatrix}/{TileRow}/{TileCol}.{Format}';
+  // TODO add layer reference
+  var vectorGetTileUrlTemplate =
+      '../../../ogcproxy?url=http://wroathiesiuxiefriepl-vectortiles.s3-website-eu-west-1.amazonaws.com/' +
+      '{Layer}/{TileMatrix}/{TileCol}/{TileRow}.{Format}';
+  
+  var getWmtsGetTileUrl = function(layer, format) {
+    return wmtsGetTileUrlTemplate
+        .replace('{Layer}', layer)
+        .replace('{Format}', format);
+  };
+  var getVectorGetTileUrl = function(layer, format) {
+    return vectorGetTileUrlTemplate
+        .replace('{Layer}', layer)
+        .replace('{Format}', format);
+  };
+
+  var createWMTSGrid = function(resolutions, origin) {
+    return new ol.tilegrid.WMTS({
+      matrixIds: $.map(resolutions, function(r, i) { return i + ''; }),
+      origin: origin,
+      resolutions: resolutions
+    });
+  }
+
+  // WMTS points layer for comparison
+  var tileGridComparison = createWMTSGrid(defaultResolutions, origin);
+  var olSourceComparison = new ol.source.WMTS({
+    dimensions: {
+      'Time': '20090401'
+    },
+    projection: 'EPSG:21781',
+    requestEncoding: 'REST',
+    tileGrid: tileGridComparison,
+    url: getWmtsGetTileUrl('ch.swisstopo.vec25-strassennetz', 'png'),
+    crossOrigin: 'anonymous'
+  });
+  olSourceComparison.getProjection().setExtent(extent);
+  var olComparisonLayer = new ol.layer.Tile({
+    source: olSourceComparison,
+    extent: olSourceComparison.getProjection().getExtent()
+  });
+
+
+  // VECTOR layer
+  var tileGrid = createWMTSGrid(defaultResolutions, origin);
+
+  // https://github.com/openlayers/ol3/blob/master/src/ol/source/wmtssource.js
+  var createFromWMTSTemplate = function(template) {
+
+    // TODO: we may want to create our own appendParams function so that params
+    // order conforms to wmts spec guidance, and so that we can avoid to escape
+    // special template params
+
+    // LG: No context for now
+    var context = {};
+    var dimensions = {};
+    var requestEncoding = 'REST';
+
+    template = (requestEncoding == ol.source.WMTSRequestEncoding.KVP) ?
+        goog.uri.utils.appendParamsFromMap(template, context) :
+        template.replace(/\{(\w+?)\}/g, function(m, p) {
+          return (p.toLowerCase() in context) ? context[p.toLowerCase()] : m;
+        });
+
+    return (
+        /**
+         * @param {ol.TileCoord} tileCoord Tile coordinate.
+         * @param {number} pixelRatio Pixel ratio.
+         * @param {ol.proj.Projection} projection Projection.
+         * @return {string|undefined} Tile URL.
+         */
+        function(tileCoord, pixelRatio, projection) {
+          if (goog.isNull(tileCoord)) {
+            return undefined;
+          } else {
+            var localContext = {
+              'TileMatrix': tileGrid.getMatrixId(tileCoord[0]),
+              'TileCol': tileCoord[1],
+              'TileRow': tileCoord[2]
+            };
+            goog.object.extend(localContext, dimensions);
+            var url = template;
+            if (requestEncoding == ol.source.WMTSRequestEncoding.KVP) {
+              url = goog.uri.utils.appendParamsFromMap(url, localContext);
+            } else {
+              url = url.replace(/\{(\w+?)\}/g, function(m, p) {
+                return localContext[p];
+              });
+            }
+            return url;
+          }
+        });
+  };
+
+  var createTileUrlFunction = function() {
+    var tileUrlFunction = ol.TileUrlFunction.nullTileUrlFunction;
+    urls = ol.TileUrlFunction.expandUrl(getVectorGetTileUrl('ch.swisstopo.vec25-strassennetz', 'topojson'));
+    tileUrlFunction = ol.TileUrlFunction.createFromTileUrlFunctions(
+        goog.array.map(urls, createFromWMTSTemplate));
+    var tmpExtent = ol.extent.createEmpty();
+
+    return ol.TileUrlFunction.withTileCoordTransform(
+        function(tileCoord, projection, opt_tileCoord) {
+          goog.asserts.assert(!goog.isNull(tileGrid),
+            'tileGrid must not be null');
+          if (tileGrid.getResolutions().length <= tileCoord[0]) {
+            return null;
+          }
+          var x = tileCoord[1];
+          var y = -tileCoord[2] - 1;
+          var tileExtent = tileGrid.getTileCoordExtent(tileCoord, tmpExtent);
+          if (!ol.extent.intersects(tileExtent, extent) ||
+              ol.extent.touches(tileExtent, extent)) {
+            return null;
+          }
+          return ol.tilecoord.createOrUpdate(tileCoord[0], x, y, opt_tileCoord);
+      }, tileUrlFunction);
+  };
+
+  var olSourceVector = new ol.source.TileVector({
+    format: new ol.format.TopoJSON({
+      defaultDataProjection: 'EPSG:21781'
+    }),
+    projection: 'EPSG:21781',
+    requestEncoding: 'REST',
+    tileGrid: tileGrid,
+    tileUrlFunction: createTileUrlFunction(),
+    crossOrigin: 'anonymous',
+    extent: extent,
+    origin: origin
+  });
+  olSourceVector.getProjection().setExtent(extent);
+
+  var roadStyles = {
+    'Autobahn': new ol.style.Style({stroke: new ol.style.Stroke({color: '#FF9500', width: 2.4})}), 
+    'Ein_Ausf': new ol.style.Style({stroke: new ol.style.Stroke({color: '#FFC069', width: 2.1})}),
+    '1_Klass': new ol.style.Style({stroke: new ol.style.Stroke({color: '#FF0000', width: 1.9})}),
+    '2_Klass': new ol.style.Style({stroke: new ol.style.Stroke({color: '#FAF200', width: 1.6})}),
+    '3_Klass': new ol.style.Style({stroke: new ol.style.Stroke({color: '#CCCCCC', width: 1.3})}),
+    '4_Klass': new ol.style.Style({stroke: new ol.style.Stroke({color: '#424241', width: 1.0})}),
+    '5_Klass': new ol.style.Style({stroke: new ol.style.Stroke({color: '#424241', width: 0.7})}),
+    '6_Klass': new ol.style.Style({stroke: new ol.style.Stroke({color: '#CCCCCC', width: 0.4})}),
+    'Q_Klass': new ol.style.Style({stroke: new ol.style.Stroke({color: '#CCCCCC', width: 0.1})})
+  };
+
+ var olVectorLayer = new ol.layer.Vector({
+    source: olSourceVector,
+    extent: extent,
+    style: function(feature) {
+      var val = feature.get('objectval').trim();
+      if (roadStyles.hasOwnProperty(val)) {
+        return [roadStyles[val]];
+      } else {
+        return [roadStyles['Q_Klass']];
+      }
+    }
+  });
+
+  olMapToposon = new ol.Map({
+    logo: false,
+    controls: ol.control.defaults({
+      attributionOptions: {
+        collapsible: false
+      }
+    }),
+    layers: [
+      olVectorLayer
+    ],
+    target: 'map-toposon',
+    view: new ol.View({
+      center: [650000, 200000],
+      resolution: 10,
+      minResolution: 2,
+      extent: extent,
+      projection: 'EPSG:21781'
+    })
+  });
+
+  olMapWMTS = new ol.Map({
+    logo: false,
+    controls: ol.control.defaults({
+      attributionOptions: {
+        collapsible: false
+      }
+    }),
+    layers: [
+      olComparisonLayer
+    ],
+    target: 'map-wmts',
+    view: new ol.View({
+      center: [650000, 200000],
+      resolution: 10,
+      minResolution: 2,
+      extent: extent,
+      projection: 'EPSG:21781'
+    })
+  });
+  olMapToposon.bindTo('view', olMapWMTS);
+});

--- a/vectorforge/templates/index.mako
+++ b/vectorforge/templates/index.mako
@@ -13,6 +13,8 @@
     <h3>WMTS demo</h3>
     <a href="../../static/examples/basicmap">Pure Ol3 WMTS example</a>
     <h3>Vector tiles demo</h3>
-    <a href="../../static/examples/geojsonpoints">Pre-generated regular tiles with geojson points</a>
+    <a href="../../static/examples/geojsonpoints">Pre-generated regular tiles of geojson points</a>
+    <br>
+    <a href="../../static/examples/topojsonlines">Pre-genertated regular tiles of simplified and quantized topojson lines</a>
   </body>
 </html>


### PR DESCRIPTION
This PR introduces a first demo for a  layer with 1'312'784 lines, so probably at least around 5'000'000 points.

I am using https://github.com/mbostock/topojson Javascript library to transform the geojson tiles into topojson tiles. This library uses Visvalingam’s algorithm for lines simplification. Link: http://bost.ocks.org/mike/simplify/
It also offers a quantization option.

Thematic filtering has been used to select main road segments first and then display less important segments as resolution increases. It is still quite approximative as I don't know the meaning of all the classes.

At very low resolution browser gets a bit laggy, but performance gets really acceptable as you zoom in. I think I could use a higher simplification and maybe use other techniques to improve the situation.

I also provide an example together with the same layer in WMTS.

I think it's a good start and it's very promising we can actually nearly already manage so many elements.
We still need to create custom ol3 build as I even needed to patch a method to make this example work.
