### PR TITLE
Adding Reference doc

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -1,0 +1,25 @@
+# Vector Tiling References
+
+## Specs
+
+[Mapbox Vector Tiles Specification](https://github.com/mapbox/vector-tile-spec)
+
+## Docs
+
+[Mapbox Vector Tiles](https://www.mapbox.com/developers/vector-tiles/)
+
+[ArcGIS Vector Tiles blog post](https://blogs.esri.com/esri/arcgis/2015/07/20/vector-tiles-preview/)
+
+## Tools
+
+[Overview](https://github.com/mapbox/awesome-vector-tiles)
+
+[PostGIS Vector Tiles Utilities](https://github.com/mapbox/postgis-vt-util)
+
+[Mapnik](http://mapnik.org/)
+
+## Demos
+
+[ArcGIS Vector Tiles](http://basemapsbeta.arcgis.com/preview/app/index.html)
+
+[Browser created GeoJSON Vector Tiles!](https://www.mapbox.com/blog/introducing-geojson-vt/)


### PR DESCRIPTION
@loicgasser Maybe such a link collection about vector tiles already exists. If so, let me know.

Here's the rendered Markdown: https://github.com/geoadmin/vector-forge/blob/gjn_refs/REFERENCES.md