### PR TITLE
Add adaptive selection logic for annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Create a json config file `config/${layerBodId}.json`.
 | minZoom                     | The minimal zoom where to start the tileing from       | 0                                          |
 | maxZoom                     | The maximal zoom where to stop the tileing at          | 26                                         |
 | gutter                      | The buffer in pixels around the tile                   | 100                                        |
+| isAnnotationLayer           | True if this is an annotation layer                    | false                                      |
+| maxFontSize                 | The maximum font size in pixels                        | 20                                         |
 | extent                      | The intersection extent selecting the tiles            | [420000.0, 30000.0, 900000.0, 350000.0]    |
 | filters                     | A List of filters                                      | []                                         |
 | lods                        | The levels of details on which to apply the filters on | No filters applied                         |

--- a/configs/dkm10_siedlungsname_anno.json
+++ b/configs/dkm10_siedlungsname_anno.json
@@ -3,7 +3,9 @@
   "tileSizePx": 256,
   "minZoom": 18,
   "maxZoom": 24,
-  "gutter": 100,
+  "gutter": 5,
+  "isAnnotationLayer": true,
+  "maxFontSize": 20,
   "extent": null,
   "filters": null,
   "lods": null


### PR DESCRIPTION
Use the length of annotations to determine which annotations cover a specific vector tile. This helps to reduce the number of features per tile without any quality impact.
The overall count of features per tile in comparison to the static approach with a fixed guttering:
-19% vs 50px gutter, -45% vs 100px gutter, +38% vs 0px gutter

Example: http://codepen.io/sbi/pen/gMOqaO